### PR TITLE
Fix: Decoding Floats

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@loopholelabs/polyglot-ts",
-  "version": "0.4.0",
+  "version": "1.0.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@loopholelabs/polyglot-ts",
-      "version": "0.4.0",
+      "version": "1.0.0",
       "license": "Apache-2.0",
       "devDependencies": {
         "@parcel/packager-ts": "^2.6.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -3559,9 +3559,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001366",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001366.tgz",
-      "integrity": "sha512-yy7XLWCubDobokgzudpkKux8e0UOOnLHE6mlNJBzT3lZJz6s5atSEzjoL+fsCPkI0G8MP5uVdDx1ur/fXEWkZA==",
+      "version": "1.0.30001495",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001495.tgz",
+      "integrity": "sha512-F6x5IEuigtUfU5ZMQK2jsy5JqUUlEFRVZq8bO2a+ysq5K7jD6PPc9YXZj78xDNS3uNchesp1Jw47YXEqr+Viyg==",
       "dev": true,
       "funding": [
         {
@@ -3571,6 +3571,10 @@
         {
           "type": "tidelift",
           "url": "https://tidelift.com/funding/github/npm/caniuse-lite"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
         }
       ]
     },
@@ -10797,7 +10801,8 @@
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
       "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "acorn-walk": {
       "version": "7.2.0",
@@ -11107,9 +11112,9 @@
       "dev": true
     },
     "caniuse-lite": {
-      "version": "1.0.30001366",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001366.tgz",
-      "integrity": "sha512-yy7XLWCubDobokgzudpkKux8e0UOOnLHE6mlNJBzT3lZJz6s5atSEzjoL+fsCPkI0G8MP5uVdDx1ur/fXEWkZA==",
+      "version": "1.0.30001495",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001495.tgz",
+      "integrity": "sha512-F6x5IEuigtUfU5ZMQK2jsy5JqUUlEFRVZq8bO2a+ysq5K7jD6PPc9YXZj78xDNS3uNchesp1Jw47YXEqr+Viyg==",
       "dev": true
     },
     "chalk": {
@@ -11788,7 +11793,8 @@
       "version": "8.5.0",
       "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-8.5.0.tgz",
       "integrity": "sha512-obmWKLUNCnhtQRKc+tmnYuQl0pFU1ibYJQ5BGhTVB08bHe9wC8qUeG7c08dj9XX+AuPj1YSGSQIHl1pnDHZR0Q==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "eslint-import-resolver-node": {
       "version": "0.3.6",
@@ -12949,7 +12955,8 @@
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/jest-pnp-resolver/-/jest-pnp-resolver-1.2.2.tgz",
       "integrity": "sha512-olV41bKSMm8BdnuMsewT4jqlZ8+3TCARAXjZGT9jcoSnrfUnRCqnMoF9XEeoWjbzObpqF9dRhHQj0Xb9QdF6/w==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "jest-regex-util": {
       "version": "28.0.2",
@@ -14818,7 +14825,8 @@
       "version": "8.8.0",
       "resolved": "https://registry.npmjs.org/ws/-/ws-8.8.0.tgz",
       "integrity": "sha512-JDAgSYQ1ksuwqfChJusw1LSJ8BizJ2e/vVu5Lxjq3YvNJNlROv1ui4i+c/kUUrPheBvQl4c5UbERhTwKa6QBJQ==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "xml-name-validator": {
       "version": "4.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@loopholelabs/polyglot-ts",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@loopholelabs/polyglot-ts",
-      "version": "1.0.0",
+      "version": "1.0.1",
       "license": "Apache-2.0",
       "devDependencies": {
         "@parcel/packager-ts": "^2.6.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@loopholelabs/polyglot-ts",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "TypeScript version of the Polyglot data encoding library.",
   "source": "src/index.ts",
   "main": "dist/main.js",

--- a/src/decoder.ts
+++ b/src/decoder.ts
@@ -205,7 +205,11 @@ export class Decoder {
     if (kind !== Kind.Uint8) {
       throw new InvalidUint8Error();
     }
-    const dataView = new DataView(this.buf.buffer, this.buf.byteOffset + this.#pos, 1);
+    const dataView = new DataView(
+      this.buf.buffer,
+      this.buf.byteOffset + this.#pos,
+      1
+    );
     const val = dataView.getUint8(0);
     this.#pos += 1;
     return val;
@@ -271,7 +275,11 @@ export class Decoder {
     if (kind !== Kind.Float32) {
       throw new InvalidFloat32Error();
     }
-    const dataView = new DataView(this.buf.buffer, this.buf.byteOffset + this.#pos, 4);
+    const dataView = new DataView(
+      this.buf.buffer,
+      this.buf.byteOffset + this.#pos,
+      4
+    );
     const val = dataView.getFloat32(0);
     this.#pos += 4;
     return val;
@@ -282,7 +290,11 @@ export class Decoder {
     if (kind !== Kind.Float64) {
       throw new InvalidFloat64Error();
     }
-    const dataView = new DataView(this.buf.buffer, this.buf.byteOffset + this.#pos, 8);
+    const dataView = new DataView(
+      this.buf.buffer,
+      this.buf.byteOffset + this.#pos,
+      8
+    );
     const val = dataView.getFloat64(0);
     this.#pos += 8;
     return val;

--- a/src/decoder.ts
+++ b/src/decoder.ts
@@ -205,7 +205,7 @@ export class Decoder {
     if (kind !== Kind.Uint8) {
       throw new InvalidUint8Error();
     }
-    const dataView = new DataView(this.buf.buffer, this.#pos, 1);
+    const dataView = new DataView(this.buf.buffer, this.buf.byteOffset + this.#pos, 1);
     const val = dataView.getUint8(0);
     this.#pos += 1;
     return val;
@@ -271,7 +271,7 @@ export class Decoder {
     if (kind !== Kind.Float32) {
       throw new InvalidFloat32Error();
     }
-    const dataView = new DataView(this.buf.buffer, this.#pos, 4);
+    const dataView = new DataView(this.buf.buffer, this.buf.byteOffset + this.#pos, 4);
     const val = dataView.getFloat32(0);
     this.#pos += 4;
     return val;
@@ -282,7 +282,7 @@ export class Decoder {
     if (kind !== Kind.Float64) {
       throw new InvalidFloat64Error();
     }
-    const dataView = new DataView(this.buf.buffer, this.#pos, 8);
+    const dataView = new DataView(this.buf.buffer, this.buf.byteOffset + this.#pos, 8);
     const val = dataView.getFloat64(0);
     this.#pos += 8;
     return val;


### PR DESCRIPTION
This PR fixes a bug when decoding Uint8s, Float32s, and Float64s in situations where the underlying decoder buffer is large and contains many other types. 